### PR TITLE
Use the cache path when testing credentials

### DIFF
--- a/nginx-cache.php
+++ b/nginx-cache.php
@@ -247,18 +247,18 @@ class NginxCache {
 
 		// buffer output
 		ob_start();
-
+		$path = get_option( 'nginx_cache_path' );
 		// load WordPress file API?
 		if ( ! function_exists( 'request_filesystem_credentials' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';
 		}
 
-		if ( ( $credentials = request_filesystem_credentials( '' ) ) === false ) {
+		if ( ( $credentials = request_filesystem_credentials( '', 'direct', false, $path, null ) ) === false ) {
 			ob_end_clean(); // prevent display of filesystem credentials form
 			return false;
 		}
 
-		if ( ! WP_Filesystem( $credentials ) ) {
+		if ( ! WP_Filesystem( $credentials, $path, true ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
I had made sure that the php user had access to delete files in cache path but the credential test did not pass due to php user didn't have access to wp-content (or perhaps the plugin dir?).
This change will test for access to cache path instead.