### PR TITLE
Try to create the cache dir if it does not exist

### DIFF
--- a/nginx-cache.php
+++ b/nginx-cache.php
@@ -247,6 +247,12 @@ class NginxCache {
 
 		$path = get_option( 'nginx_cache_path' );
 
+		// The $path is set; however the directory doesn't exist so let's try and
+		// create the directory before failing
+		if ( ! file_exists( $path ) ) {
+			mkdir( $path );
+		}
+
 		// load WordPress file API?
 		if ( ! function_exists( 'request_filesystem_credentials' ) ) {
 			require_once ABSPATH . 'wp-admin/includes/file.php';


### PR DESCRIPTION
This is an attempt to avoid the error `Filesystem API could not be
initialized.` after the cache directory has been purged.