### PR TITLE
Add support for NGINX_CACHE_PATH constant in wp-config.php

### DIFF
--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -15,8 +15,14 @@
 			<tr valign="top">
 				<th scope="row"><?php _e( 'Cache Zone Path', 'nginx-cache' ); ?></th>
 				<td>
-					<input type="text" class="regular-text code" name="nginx_cache_path" placeholder="/data/nginx/cache" value="<?php echo esc_attr( get_option( 'nginx_cache_path' ) ); ?>" />
+					<?php $path_via_constant = defined( 'NGINX_CACHE_PATH' ); ?>
+					<input type="text" class="regular-text code" name="nginx_cache_path" placeholder="/data/nginx/cache" value="<?php echo esc_attr( $path_via_constant ? NGINX_CACHE_PATH : get_option( 'nginx_cache_path' ) ); ?>"<?php if ( $path_via_constant ) : ?> readonly="readonly"<?php endif; ?> />
+					<?php if ( $path_via_constant ) : ?>
+					<p class="description"><?php _e( 'The cache zone path is set via the <code>NGINX_CACHE_PATH</code> constant in <code>wp-config.php</code> and cannot be changed here.', 'nginx-cache' ); ?></p>
+					<?php else : ?>
 					<p class="description"><?php _e( 'The absolute path to the location of the cache zone, specified in the Nginx <code>fastcgi_cache_path</code> or <code>proxy_cache_path</code> directive.', 'nginx-cache' ); ?></p>
+					<p class="description"><?php _e( 'You can also define this path permanently by adding <code>define( \'NGINX_CACHE_PATH\', \'/data/nginx/cache\' );</code> to your <code>wp-config.php</code>.', 'nginx-cache' ); ?></p>
+					<?php endif; ?>
 				</td>
 			</tr>
 			<tr valign="top">

--- a/includes/settings-page.php
+++ b/includes/settings-page.php
@@ -17,11 +17,12 @@
 				<td>
 					<?php $path_via_constant = defined( 'NGINX_CACHE_PATH' ); ?>
 					<input type="text" class="regular-text code" name="nginx_cache_path" placeholder="/data/nginx/cache" value="<?php echo esc_attr( $path_via_constant ? NGINX_CACHE_PATH : get_option( 'nginx_cache_path' ) ); ?>"<?php if ( $path_via_constant ) : ?> readonly="readonly"<?php endif; ?> />
+
 					<?php if ( $path_via_constant ) : ?>
-					<p class="description"><?php _e( 'The cache zone path is set via the <code>NGINX_CACHE_PATH</code> constant in <code>wp-config.php</code> and cannot be changed here.', 'nginx-cache' ); ?></p>
+						<p class="description"><?php _e( 'The cache zone path is set via the <code>NGINX_CACHE_PATH</code> constant in <code>wp-config.php</code> and cannot be changed here.', 'nginx-cache' ); ?></p>
 					<?php else : ?>
-					<p class="description"><?php _e( 'The absolute path to the location of the cache zone, specified in the Nginx <code>fastcgi_cache_path</code> or <code>proxy_cache_path</code> directive.', 'nginx-cache' ); ?></p>
-					<p class="description"><?php _e( 'You can also define this path permanently by adding <code>define( \'NGINX_CACHE_PATH\', \'/data/nginx/cache\' );</code> to your <code>wp-config.php</code>.', 'nginx-cache' ); ?></p>
+						<p class="description"><?php _e( 'The absolute path to the location of the cache zone, specified in the Nginx <code>fastcgi_cache_path</code> or <code>proxy_cache_path</code> directive.', 'nginx-cache' ); ?></p>
+						<p class="description"><?php _e( 'You can also define this path permanently by adding <code>define( \'NGINX_CACHE_PATH\', \'/data/nginx/cache\' );</code> to your <code>wp-config.php</code>.', 'nginx-cache' ); ?></p>
 					<?php endif; ?>
 				</td>
 			</tr>

--- a/nginx-cache.php
+++ b/nginx-cache.php
@@ -69,14 +69,14 @@ class NginxCache {
 
 	}
 
-	private function get_cache_path()
-	{
+	private function get_cache_path() {
 
-		if (defined('NGINX_CACHE_PATH')) {
-			return sanitize_text_field(NGINX_CACHE_PATH);
+		if ( defined( 'NGINX_CACHE_PATH' ) ) {
+			return sanitize_text_field( NGINX_CACHE_PATH );
 		}
 
-		return get_option('nginx_cache_path');
+		return get_option( 'nginx_cache_path' );
+
 	}
 
 	public function add_settings_notices() {

--- a/nginx-cache.php
+++ b/nginx-cache.php
@@ -69,6 +69,16 @@ class NginxCache {
 
 	}
 
+	private function get_cache_path()
+	{
+
+		if (defined('NGINX_CACHE_PATH')) {
+			return sanitize_text_field(NGINX_CACHE_PATH);
+		}
+
+		return get_option('nginx_cache_path');
+	}
+
 	public function add_settings_notices() {
 
 		$path_error = $this->is_valid_path();
@@ -171,7 +181,7 @@ class NginxCache {
 
 		global $wp_filesystem;
 
-		$path = get_option( 'nginx_cache_path' );
+		$path = $this->get_cache_path();
 
 		if ( empty( $path ) ) {
 			return new WP_Error( 'empty', __( '"Cache Zone Path" is not set.', 'nginx-cache' ) );
@@ -248,7 +258,7 @@ class NginxCache {
 			return false;
 		}
 
-		$path = get_option( 'nginx_cache_path' );
+		$path = $this->get_cache_path();
 		$path_error = $this->is_valid_path();
 
 		// abort if cache zone path is not valid
@@ -285,7 +295,7 @@ class NginxCache {
 
 	private function initialize_filesystem() {
 
-		$path = get_option( 'nginx_cache_path' );
+		$path = $this->get_cache_path();
 
 		// if the cache directory doesn't exist, try to create it
 		if ( ! file_exists( $path ) ) {


### PR DESCRIPTION
## Summary

This PR allows the FastCGI cache path to be defined via a constant in `wp-config.php`, instead of only through the admin settings UI.

## Usage

Add the following to your `wp-config.php`:

```php
define( 'NGINX_CACHE_PATH', '/data/nginx/cache' );
```

## Behavior

- When `NGINX_CACHE_PATH` is defined, it takes precedence over the value stored in the database.
- The "Cache Zone Path" field in the admin settings page becomes read-only with an explanatory notice.
- When the constant is not defined, existing behavior is unchanged. A hint is shown below the field explaining how to set the path via `wp-config.php`.