### PR TITLE
Fix PHP Warning in recursive subdirectory validation

### DIFF
--- a/nginx-cache.php
+++ b/nginx-cache.php
@@ -229,7 +229,7 @@ class NginxCache {
 			}
 
 			// validate subdirectories recursively
-			if ( $item[ 'type' ] === 'd' && ! $this->validate_dirlist( $item[ 'files' ] ) ) {
+			if ( $item[ 'type' ] === 'd' && is_array( $item[ 'files' ] ) && ! $this->validate_dirlist( $item[ 'files' ] ) ) {
 				return false;
 			}
 


### PR DESCRIPTION
### Problem
Under concurrent load (e.g., when a concurrent `purge_zone()` call deletes and recreates the cache directory while another request is executing `is_valid_path()`), subdirectories can disappear mid-traversal. 

When this happens, `WP_Filesystem_Direct::dirlist()` returns `false` for the subdirectory's files. Because `validate_dirlist()` was recursively passing `$item['files']` without validation, it triggered the following warning:
```
PHP Warning: foreach() argument must be of type array|object, false given
```
This warning also halts the validation flow, potentially causing `is_valid_path()` to return an incorrect result.

While `is_valid_path()` already safely guards its top-level `dirlist()` call with an `is_array()` check, the recursive call inside `validate_dirlist()` was missing this protection.

### Solution
Added an `is_array( $item['files'] )` check before the recursive call. This ensures that if a subdirectory becomes unreadable or is deleted during the process, it is safely skipped rather than triggering a PHP warning. This change aligns with the existing validation logic used at the top level.